### PR TITLE
Purge content from Fastly CDN after success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,6 @@ script:
   - cp _site-validation/site-validation.md _pages
   - jekyll build
   - pytest
+
+after_success:
+  - test $TRAVIS_BRANCH = "master" && curl -X POST --header "Fastly-Key: $FASTLY_API_TOKEN" https://api.fastly.com/service/$FASTLY_SERVICE/purge_all


### PR DESCRIPTION
If there is an easy way of knowing which pages were updated we can purge only those instead. For starters, let's purge everything for simplicity.